### PR TITLE
`az containerapp up --repo`: use new secret store interface

### DIFF
--- a/src/containerapp/azext_containerapp/_github_oauth.py
+++ b/src/containerapp/azext_containerapp/_github_oauth.py
@@ -9,7 +9,7 @@ import sys
 from datetime import datetime
 
 from knack.log import get_logger
-from azure.cli.core.util import open_page_in_browser
+from azure.cli.core.util import open_page_in_browser, get_secret_store
 from azure.cli.core.auth.persistence import SecretStore, build_persistence
 from azure.cli.core.azclierror import (ValidationError, CLIInternalError, UnclassifiedUserFault)
 
@@ -33,11 +33,7 @@ GITHUB_OAUTH_SCOPES = [
 
 
 def _get_github_token_secret_store(cmd):
-    location = os.path.join(cmd.cli_ctx.config.config_dir, "github_token_cache")
-    # TODO use core CLI util to take care of this once it's merged and released
-    encrypt = sys.platform.startswith('win32')  # encryption not supported on non-windows platforms
-    file_persistence = build_persistence(location, encrypt)
-    return SecretStore(file_persistence)
+    return get_secret_store(cmd.cli_ctx, "github_token_cache")
 
 
 def cache_github_token(cmd, token, repo):


### PR DESCRIPTION
---

Rewrites the GitHub credential caching to use @jiasli's new secret store interface in the core CLI utils: https://github.com/Azure/azure-cli/pull/22372

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
