### PR TITLE
Fix custom domain removal from `az containerapp up`

### DIFF
--- a/src/containerapp/HISTORY.rst
+++ b/src/containerapp/HISTORY.rst
@@ -8,7 +8,7 @@ Release History
 * Added parameter --environment to 'az containerapp list'
 * Added 'az containerapp revision label swap' to swap traffic labels
 * BREAKING CHANGE: 'az containerapp revision list' now shows only active revisions by default, added flag --all to show all revisions
-
+* Fixed but with 'az containerapp up' where custom domains would be removed when updating existing containerapp
 
 0.3.5
 ++++++

--- a/src/containerapp/azext_containerapp/custom.py
+++ b/src/containerapp/azext_containerapp/custom.py
@@ -2344,7 +2344,10 @@ def containerapp_up_logic(cmd, resource_group_name, name, managed_env, image, en
 
     ingress_def = None
     if target_port is not None and ingress is not None:
-        ingress_def = IngressModel
+        if ca_exists:
+            ingress_def = containerapp_def["properties"]["configuration"]["ingress"]
+        else:
+            ingress_def = IngressModel
         ingress_def["external"] = external_ingress
         ingress_def["targetPort"] = target_port
         containerapp_def["properties"]["configuration"]["ingress"] = ingress_def


### PR DESCRIPTION
---

Fixes a [bug](https://github.com/microsoft/azure-container-apps/issues/234) where calling `az containerapp up` on an existing app with a custom domain clears the custom domain 

This checklist is used to make sure that common guidelines for a pull request are followed.

### General Guidelines

- [ ] Have you run `azdev style <YOUR_EXT>` locally? (`pip install azdev` required)
- [ ] Have you run `python scripts/ci/test_index.py -q` locally?

For new extensions:

- [ ] My extension description/summary conforms to the [Extension Summary Guidelines](https://github.com/Azure/azure-cli/blob/dev/doc/extensions/extension_summary_guidelines.md).


### About Extension Publish

There is a pipeline to automatically build, upload and publish extension wheels.  
Once your PR is merged into master branch, a new PR will be created to update `src/index.json` automatically.  
The precondition is to put your code inside this repo and upgrade the version in the PR but do not modify `src/index.json`. 
